### PR TITLE
Fix Vercel handler

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI, Query, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
+from mangum import Mangum
 import os
 import time
 
@@ -112,5 +113,5 @@ def get_articles(
         "note": "当前返回模拟数据，环境变量配置正常后将调用真实API"
     }
 
-# 简单导出供Vercel使用
-handler = app 
+# 使用Mangum包装FastAPI应用供Vercel使用
+handler = Mangum(app)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.104.1
 uvicorn[standard]==0.24.0
 requests==2.31.0
-python-multipart==0.0.6 
+python-multipart==0.0.6
+mangum==0.17.0


### PR DESCRIPTION
## Summary
- export FastAPI app through Mangum for Vercel
- add `mangum` dependency

## Testing
- `python -m py_compile api/index.py local_test.py deploy.py test_remote.py`

------
https://chatgpt.com/codex/tasks/task_e_68468946c4c0832db50f911bb397c9c8